### PR TITLE
change port from int16 to uint16

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,5 +2,5 @@ package libtorrent
 
 type Config struct {
 	RootDirectory string
-	Port          int16
+	Port          uint16
 }

--- a/listener.go
+++ b/listener.go
@@ -6,12 +6,12 @@ import (
 )
 
 type Listener struct {
-	port     int16
+	port     uint16
 	torrents map[string]*Torrent
 	listener net.Listener
 }
 
-func NewListener(port int16) (l *Listener) {
+func NewListener(port uint16) (l *Listener) {
 	l = &Listener{
 		port:     port,
 		torrents: make(map[string]*Torrent),

--- a/torrent.go
+++ b/torrent.go
@@ -267,7 +267,7 @@ func (t *Torrent) Left() int64 {
 	return 0
 }
 
-func (t *Torrent) Port() int16 {
+func (t *Torrent) Port() uint16 {
 	return t.config.Port
 }
 

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -31,7 +31,7 @@ type TorrentStatter interface {
 	Downloaded() int64
 	Uploaded() int64
 	Left() int64
-	Port() int16
+	Port() uint16
 	PeerId() []byte
 }
 
@@ -232,7 +232,7 @@ type announceRequest struct {
 	ipAddress     int32
 	key           int32
 	numWant       int32
-	port          int16
+	port          uint16
 }
 
 func (a *announceRequest) BinaryDump(w io.Writer) (err error) {


### PR DESCRIPTION
Does precisely what it says. Ports above 32767 don't fit in an `int16` so I changed it to `uint16`.
